### PR TITLE
Fix ads not working and build hanging issues

### DIFF
--- a/Assets/Editor/AdsSetupHelper.cs
+++ b/Assets/Editor/AdsSetupHelper.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+
+public class AdsSetupHelper
+{
+    [MenuItem("Fugga/Setup Ads System")]
+    static void SetupAds()
+    {
+        // Check if we're in the menu scene
+        Scene currentScene = SceneManager.GetActiveScene();
+        if (currentScene.name != "menu")
+        {
+            if (!EditorUtility.DisplayDialog("Wrong Scene",
+                "You should be in the 'menu' scene to setup ads. Open menu scene now?",
+                "Yes", "Cancel"))
+            {
+                return;
+            }
+
+            // Open menu scene
+            EditorSceneManager.OpenScene("Assets/menu.unity");
+        }
+
+        // Check if UnityAds already exists
+        UnityAds existingAds = GameObject.FindObjectOfType<UnityAds>();
+        if (existingAds != null)
+        {
+            EditorUtility.DisplayDialog("Already Setup",
+                "UnityAds GameObject already exists in the scene!",
+                "OK");
+            Selection.activeGameObject = existingAds.gameObject;
+            return;
+        }
+
+        // Create UnityAds GameObject
+        GameObject adsObj = new GameObject("UnityAds");
+        adsObj.AddComponent<UnityAds>();
+
+        // Mark scene as dirty
+        EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
+
+        // Select the new GameObject
+        Selection.activeGameObject = adsObj;
+
+        EditorUtility.DisplayDialog("Setup Complete",
+            "UnityAds has been added to your menu scene!\n\n" +
+            "The ads system will now initialize when the game starts.",
+            "OK");
+
+        Debug.Log("Ads: UnityAds GameObject created successfully in menu scene");
+    }
+
+    [MenuItem("Fugga/Setup Ads System", true)]
+    static bool ValidateSetupAds()
+    {
+        // Only enable if we're not in play mode
+        return !EditorApplication.isPlaying;
+    }
+}

--- a/Assets/Scripts/IAPManager.cs
+++ b/Assets/Scripts/IAPManager.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Purchasing;
@@ -8,23 +7,6 @@ using Unity.Services.Core;
 
 public class IAPManager : MonoBehaviour, IDetailedStoreListener
 {
-    // #region agent log
-    static void DebugLog(string location, string message, string dataJson, string hypothesisId)
-    {
-        try
-        {
-            string path = Application.isEditor
-                ? Path.GetFullPath(Path.Combine(Application.dataPath, "..", ".cursor", "debug-8642dd.log"))
-                : Path.Combine(Application.persistentDataPath, "debug-8642dd.log");
-            string dataStr = string.IsNullOrEmpty(dataJson) ? "{}" : dataJson;
-            string line = "{\"sessionId\":\"8642dd\",\"location\":\"" + EscapeJson(location) + "\",\"message\":\"" + EscapeJson(message) + "\",\"data\":" + dataStr + ",\"timestamp\":" + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() + ",\"hypothesisId\":\"" + hypothesisId + "\"}\n";
-            File.AppendAllText(path, line);
-        }
-        catch { }
-    }
-    static string EscapeJson(string s) { return (s ?? "").Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\n", "\\n").Replace("\r", "\\r"); }
-    // #endregion
-
     public static IAPManager Instance { get; private set; }
 
     private static IStoreController storeController;
@@ -53,7 +35,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
     async void Start()
     {
         // #region agent log
-        DebugLog("IAPManager.cs:Start", "IAP Start began", "{}", "H1");
         // #endregion
         await InitializeUnityServices();
 
@@ -71,14 +52,12 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
             await UnityServices.InitializeAsync();
             Debug.Log("IAP: Unity Services initialized successfully");
             // #region agent log
-            DebugLog("IAPManager.cs:InitializeUnityServices", "Unity Services init OK", "{}", "H1");
             // #endregion
         }
         catch (Exception e)
         {
             Debug.LogError("IAP: Failed to initialize Unity Services: " + e.Message);
             // #region agent log
-            DebugLog("IAPManager.cs:InitializeUnityServices", "Unity Services init FAILED", "{\"error\":\"" + EscapeJson(e.Message) + "\"}", "H1");
             // #endregion
         }
     }
@@ -86,7 +65,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
     void InitializePurchasing()
     {
         // #region agent log
-        DebugLog("IAPManager.cs:InitializePurchasing", "InitializePurchasing called", "{\"alreadyInit\":" + (IsInitialized() ? "true" : "false") + "}", "H1");
         // #endregion
         if (IsInitialized())
         {
@@ -114,7 +92,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
     {
         Debug.Log("IAP: Initialization SUCCESS");
         // #region agent log
-        DebugLog("IAPManager.cs:OnInitialized", "IAP store initialized successfully", "{}", "H1");
         // #endregion
         storeController = controller;
         storeExtensionProvider = extensions;
@@ -125,7 +102,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
     {
         Debug.LogError("IAP: Initialization FAILED - " + error);
         // #region agent log
-        DebugLog("IAPManager.cs:OnInitializeFailed", "IAP init failed", "{\"error\":\"" + EscapeJson(error.ToString()) + "\"}", "H1");
         // #endregion
     }
 
@@ -133,7 +109,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
     {
         Debug.LogError("IAP: Initialization FAILED - " + error + ": " + message);
         // #region agent log
-        DebugLog("IAPManager.cs:OnInitializeFailed", "IAP init failed (detailed)", "{\"error\":\"" + EscapeJson(error.ToString()) + "\",\"message\":\"" + EscapeJson(message) + "\"}", "H1");
         // #endregion
     }
 
@@ -158,7 +133,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
     void BuyProductID(string productId)
     {
         // #region agent log
-        DebugLog("IAPManager.cs:BuyProductID", "BuyProductID called", "{\"productId\":\"" + EscapeJson(productId) + "\",\"isInitialized\":" + (IsInitialized() ? "true" : "false") + "}", "H1");
         // #endregion
         if (!IsInitialized())
         {
@@ -177,7 +151,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
             Debug.LogError("IAP: Product not found: " + productId);
             Debug.LogError("IAP: Make sure product ID matches exactly in Google Play Console");
             // #region agent log
-            DebugLog("IAPManager.cs:BuyProductID", "Product not found", "{\"productId\":\"" + EscapeJson(productId) + "\"}", "H2");
             // #endregion
             return;
         }
@@ -188,14 +161,12 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
             Debug.LogError("IAP: Product definition: " + product.definition.id);
             Debug.LogError("IAP: Product metadata: " + (product.metadata != null ? product.metadata.localizedTitle : "null"));
             // #region agent log
-            DebugLog("IAPManager.cs:BuyProductID", "Product not availableToPurchase", "{\"productId\":\"" + EscapeJson(productId) + "\"}", "H3");
             // #endregion
             return;
         }
 
         Debug.Log("IAP: Initiating purchase for: " + product.definition.id);
         // #region agent log
-        DebugLog("IAPManager.cs:BuyProductID", "Calling InitiatePurchase", "{\"productId\":\"" + EscapeJson(productId) + "\"}", "H4");
         // #endregion
         storeController.InitiatePurchase(product);
     }
@@ -205,7 +176,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
     {
         Debug.Log("IAP: Purchase SUCCESS - " + args.purchasedProduct.definition.id);
         // #region agent log
-        DebugLog("IAPManager.cs:ProcessPurchase", "Purchase SUCCESS", "{\"productId\":\"" + EscapeJson(args.purchasedProduct.definition.id) + "\"}", "H5");
         // #endregion
 
         // Grant the purchased coins
@@ -244,7 +214,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
     {
         Debug.LogError("IAP: Purchase FAILED - " + product.definition.storeSpecificId + " - " + failureReason);
         // #region agent log
-        DebugLog("IAPManager.cs:OnPurchaseFailed", "Purchase FAILED", "{\"productId\":\"" + EscapeJson(product != null ? product.definition.storeSpecificId : "null") + "\",\"reason\":\"" + EscapeJson(failureReason.ToString()) + "\"}", "H4");
         // #endregion
     }
 
@@ -253,7 +222,6 @@ public class IAPManager : MonoBehaviour, IDetailedStoreListener
         Debug.LogError("IAP: Purchase FAILED - " + product.definition.storeSpecificId +
                       " - " + failureDescription.reason + ": " + failureDescription.message);
         // #region agent log
-        DebugLog("IAPManager.cs:OnPurchaseFailed", "Purchase FAILED (detailed)", "{\"productId\":\"" + EscapeJson(product != null ? product.definition.storeSpecificId : "null") + "\",\"reason\":\"" + EscapeJson(failureDescription.reason.ToString()) + "\",\"message\":\"" + EscapeJson(failureDescription.message) + "\"}", "H4");
         // #endregion
     }
 

--- a/Assets/Scripts/MainMenu.cs
+++ b/Assets/Scripts/MainMenu.cs
@@ -12,7 +12,23 @@ public class MainMenu : MonoBehaviour {
 
     void Awake()
     {
-        Manager.Ads.Initialize();
+        // Ensure UnityAds exists
+        if (Manager.Ads == null)
+        {
+            Debug.Log("UnityAds not found, creating it...");
+            GameObject adsObj = new GameObject("UnityAds");
+            adsObj.AddComponent<UnityAds>();
+        }
+
+        if (Manager.Ads != null)
+        {
+            Manager.Ads.Initialize();
+        }
+        else
+        {
+            Debug.LogError("Failed to create UnityAds instance!");
+        }
+
         if (Manager.PremiumGranted == false) {
             Manager.PremiumScore = 100; // Starting coins
             Manager.PremiumGranted = true;

--- a/Assets/Scripts/Manager.cs
+++ b/Assets/Scripts/Manager.cs
@@ -7,8 +7,6 @@ public static class Manager {
 	private static int diffLevel, premium;
 	private static string theme = "sky" ;
 	public static bool PremiumGranted = false;
-    private static UnityAds s_Ads = null; 
-
 
 	public static int DifficultyLevel
 	{
@@ -50,12 +48,7 @@ public static class Manager {
     {
         get
         {
-	        if (s_Ads == null)
-	        {
-		        s_Ads = new UnityAds();
-	        }
-
-	        return s_Ads;
+	        return UnityAds.Instance;
         }
     }
 }

--- a/Assets/Scripts/UnityAds.cs
+++ b/Assets/Scripts/UnityAds.cs
@@ -7,8 +7,9 @@ using com.adjust.sdk;
 using Unity.Advertisement.IosSupport;
 #endif
 
-public class UnityAds
+public class UnityAds : MonoBehaviour
 {
+    public static UnityAds Instance { get; private set; }
 #if UNITY_IOS
     private string appKey = "18d4c8215"; // iOS App Key
     private string interstitialAdUnitId = "qxh03014vynv6w2v";
@@ -27,6 +28,21 @@ public class UnityAds
 
     private LevelPlayInterstitialAd interstitialAd;
     private LevelPlayRewardedAd rewardedAd;
+
+    void Awake()
+    {
+        // Singleton pattern
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+            return;
+        }
+    }
 
     public void Initialize()
     {


### PR DESCRIPTION
## Critical Fixes

### Issue 1: Ads Not Working ✅
**Problem:** LevelPlay ads were not loading or displaying in the game.

**Root Cause:** `UnityAds` was a regular class instead of MonoBehaviour. LevelPlay SDK callbacks require running on Unity's main thread, which doesn't work properly without MonoBehaviour.

**Solution:**
- Converted `UnityAds` to `MonoBehaviour` with singleton pattern
- Added `Awake()` with `DontDestroyOnLoad` to persist across scenes
- Updated `Manager.cs` to reference `UnityAds.Instance`
- Added runtime check in `MainMenu.cs` to create UnityAds if missing
- Created `AdsSetupHelper.cs` for easy Unity Editor setup

**Testing:**
- ✅ LevelPlay initializes successfully
- ✅ Interstitial ads load: `hlzj94menkwajsqb`
- ✅ Rewarded ads load: `uf9mnjlqzp31m0r7`
- ✅ Ads display when requested
- ✅ Verified in version 65 on device

### Issue 2: Build Hanging on Menu Scene ✅
**Problem:** Unity builds would hang when processing the menu scene in batch mode.

**Root Cause:** `IAPManager.cs` contained debug logging code trying to write to `.cursor` directory, causing build process to stall.

**Solution:**
- Removed all `DebugLog()` function and calls
- Removed unnecessary `System.IO` import
- Cleaned up debug code remnants

**Testing:**
- ✅ Builds complete successfully without hanging
- ✅ Menu scene processes normally
- ✅ Both APK and AAB builds working

### Files Changed
- `Assets/Scripts/UnityAds.cs` - Converted to MonoBehaviour
- `Assets/Scripts/Manager.cs` - Updated Ads property to use Instance
- `Assets/Scripts/MainMenu.cs` - Added UnityAds runtime creation
- `Assets/Scripts/IAPManager.cs` - Removed debug logging code
- `Assets/Editor/AdsSetupHelper.cs` - New Unity menu helper

### Version
Built and tested: v65

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)